### PR TITLE
Small patch to add the ability to run the ADT Explorer in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:latest
+
+# Create app directory
+WORKDIR /usr/src/app/client
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY ./client/package*.json ./
+WORKDIR /usr/src/app/client/src
+RUN npm install
+# If you are building your code for production
+# RUN npm ci --only=production
+
+# Bundle app source
+WORKDIR /usr/src/app
+COPY . .
+
+# Notify that we want to expose port 3000
+EXPOSE 3000
+# Actually start the app
+WORKDIR /usr/src/app/client/src
+CMD npm run start

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Node.js 10+
 1. From a command prompt in the root folder, run `docker build -t adt-explorer .`. This will build the Docker image for the ADT explorer.
 1. From the same command prompt, run `docker run -it -p3000:3000 adt-explorer`.
     > By default, the app runs on port 3000. To customize the port, change the run command. For example, to use port 8080 run `docker run -it -p8080:3000 adt-explorer`
-    > Note: When run successfully the application will display a message showing you the URL & port that you must open to browse the app. When running the app inside docker this information might not be accurate, as other port might have been exposed. Be sure to use
-    the port you chose before.
-    > Note: Your ADT app registration must have a reply URL using the same port you are using - e.g. `localhost:7000` if that is the port you are using.
+    >  * Note: When run successfully the application will display a message showing you the URL & port that you must open to browse the app. When running the app inside Docker this information might not be accurate, as other port might have been exposed. Be sure to use
+    >  the port you chose before.
+    >  * Note: Your ADT app registration must have a reply URL using the same port you are using - e.g. `localhost:7000` if that is the port you are using.
 1. You can now open your web browser and browse to `http://localhost:3000` (change `3000` for the apropriate port, if you changed it) and the app should appear.
 
 ## Quick Start: Create an Example Graph

--- a/README.md
+++ b/README.md
@@ -49,6 +49,23 @@ Node.js 10+
     > Note: Your ADT app registration must have a reply URL using the same port you are using - e.g. localhost:7000 if that is the port you are using.
 1. Your browser should open and the app should appear.
 
+### Running adt-explorer with Docker
+
+1. Set up an Azure Digital Twins service instance with an Azure Active Directory client app registration. For instructions, please see the following how-to articles:
+    * [Set up an Azure Digital Twins instance](https://docs.microsoft.com/azure/digital-twins/how-to-set-up-instance)
+    * [Authenticate an Azure Digital Twins client application](https://docs.microsoft.com/azure/digital-twins/how-to-authenticate-client). The important part is the creation of the app registration (client id).
+      > A few important aspects for your app registrations:
+      > * Make sure you add app registrations to the Web platform section of the app registration, not the desktop/mobile section.
+      > * When adding callback URLs to the app registration, please make sure to add `http://localhost:3000`. You can run adt-explorer with a different port (see below), but this is the default.
+      > * Check the **Access Tokens** toggle in the **Implicit Grants** section a few paragraphs below the **Platform Configuration** section on the page. If this toggle is not checked, you will not get authorization tokens.  
+1. From a command prompt in the root folder, run `docker build -t adt-explorer .`. This will build the Docker image for the ADT explorer.
+1. From the same command prompt, run `docker run -it -p3000:3000 adt-explorer`.
+    > By default, the app runs on port 3000. To customize the port, change the run command. For example, to use port 8080 run `docker run -it -p8080:3000 adt-explorer`
+    > Note: When run successfully the application will display a message showing you the URL & port that you must open to browse the app. When running the app inside docker this information might not be accurate, as other port might have been exposed. Be sure to use
+    the port you chose before.
+    > Note: Your ADT app registration must have a reply URL using the same port you are using - e.g. `localhost:7000` if that is the port you are using.
+1. You can now open your web browser and browse to `http://localhost:3000` (change `3000` for the apropriate port, if you changed it) and the app should appear.
+
 ## Quick Start: Create an Example Graph
 
 To create an example graph with adt-explorer connected to a fresh instance of Azure Digital Twins, follow the steps below. The result will be the graph in the screenshot above.

--- a/README.md
+++ b/README.md
@@ -49,22 +49,7 @@ Node.js 10+
     > Note: Your ADT app registration must have a reply URL using the same port you are using - e.g. localhost:7000 if that is the port you are using.
 1. Your browser should open and the app should appear.
 
-### Running adt-explorer with Docker
-
-1. Set up an Azure Digital Twins service instance with an Azure Active Directory client app registration. For instructions, please see the following how-to articles:
-    * [Set up an Azure Digital Twins instance](https://docs.microsoft.com/azure/digital-twins/how-to-set-up-instance)
-    * [Authenticate an Azure Digital Twins client application](https://docs.microsoft.com/azure/digital-twins/how-to-authenticate-client). The important part is the creation of the app registration (client id).
-      > A few important aspects for your app registrations:
-      > * Make sure you add app registrations to the Web platform section of the app registration, not the desktop/mobile section.
-      > * When adding callback URLs to the app registration, please make sure to add `http://localhost:3000`. You can run adt-explorer with a different port (see below), but this is the default.
-      > * Check the **Access Tokens** toggle in the **Implicit Grants** section a few paragraphs below the **Platform Configuration** section on the page. If this toggle is not checked, you will not get authorization tokens.  
-1. From a command prompt in the root folder, run `docker build -t adt-explorer .`. This will build the Docker image for the ADT explorer.
-1. From the same command prompt, run `docker run -it -p3000:3000 adt-explorer`.
-    > By default, the app runs on port 3000. To customize the port, change the run command. For example, to use port 8080 run `docker run -it -p8080:3000 adt-explorer`
-    >  * Note: When run successfully the application will display a message showing you the URL & port that you must open to browse the app. When running the app inside Docker this information might not be accurate, as other port might have been exposed. Be sure to use
-    >  the port you chose before.
-    >  * Note: Your ADT app registration must have a reply URL using the same port you are using - e.g. `localhost:7000` if that is the port you are using.
-1. You can now open your web browser and browse to `http://localhost:3000` (change `3000` for the apropriate port, if you changed it) and the app should appear.
+See below for instructions on how to run adt-explorer using docker.
 
 ## Quick Start: Create an Example Graph
 
@@ -227,6 +212,23 @@ Clicking the settings cog in the top right corner allows the configuration of th
 
 * adt-explorer does not currently handle complex properties or components defined in twins well. You can create or visualize twins using these features, but you may not be able to view or edit their properties
 * The display of patches in the property inspector is not always correct if you perform multiple patches in a sequence. The changes should be correctly applied to th service twin, though
+
+## Running adt-explorer with Docker
+
+1. Set up an Azure Digital Twins service instance with an Azure Active Directory client app registration. For instructions, please see the following how-to articles:
+    * [Set up an Azure Digital Twins instance](https://docs.microsoft.com/azure/digital-twins/how-to-set-up-instance)
+    * [Authenticate an Azure Digital Twins client application](https://docs.microsoft.com/azure/digital-twins/how-to-authenticate-client). The important part is the creation of the app registration (client id).
+      > A few important aspects for your app registrations:
+      > * Make sure you add app registrations to the Web platform section of the app registration, not the desktop/mobile section.
+      > * When adding callback URLs to the app registration, please make sure to add `http://localhost:3000`. You can run adt-explorer with a different port (see below), but this is the default.
+      > * Check the **Access Tokens** toggle in the **Implicit Grants** section a few paragraphs below the **Platform Configuration** section on the page. If this toggle is not checked, you will not get authorization tokens.  
+1. From a command prompt in the root folder, run `docker build -t adt-explorer .`. This will build the Docker image for the ADT explorer.
+1. From the same command prompt, run `docker run -it -p3000:3000 adt-explorer`.
+    > By default, the app runs on port 3000. To customize the port, change the run command. For example, to use port 8080 run `docker run -it -p8080:3000 adt-explorer`
+    >  * Note: When run successfully the application will display a message showing you the URL & port that you must open to browse the app. When running the app inside Docker this information might not be accurate, as other port might have been exposed. Be sure to use
+    >  the port you chose before.
+    >  * Note: Your ADT app registration must have a reply URL using the same port you are using - e.g. `localhost:7000` if that is the port you are using.
+1. You can now open your web browser and browse to `http://localhost:3000` (change `3000` for the apropriate port, if you changed it) and the app should appear.
 
 ## Experimental Features
 


### PR DESCRIPTION
  * Added a Dockerfile, tested in Docker 2.3.0.4
  * Added instructions to the README.md file

Please note that the `-it` in the `docker run` command is very important, otherwise the app exits during startup. Can this behaviour be related to [this bug](https://github.com/facebook/create-react-app/issues/8688)?

Even if the pull request if pretty small, let me know if any other changes are required.