### PR TITLE
Fix for ADT URL requires http prefix.

### DIFF
--- a/client/src/services/ApiService.js
+++ b/client/src/services/ApiService.js
@@ -42,6 +42,13 @@ class ApiService {
     this.clientOptions = null;
   }
 
+  async addhttp(url) {
+    if (!/^(?:f|ht)tps?:\/\//.test(url)) {
+        url = "http://" + url;
+    }
+    return url;
+  }
+
   async initialize() {
     const accessToken = await authService.login();
     if (!accessToken) {
@@ -58,7 +65,7 @@ class ApiService {
     this.client = new AzureDigitalTwinsAPI(tokenCredentials, clientConfig);
 
     const { appAdtUrl } = await configService.getConfig();
-    this.clientOptions = { customHeaders: { "x-adt-host": new URL(appAdtUrl).hostname } };
+    this.clientOptions = { customHeaders: { "x-adt-host": new URL(await this.addhttp(appAdtUrl)).hostname } };
   }
 
   async queryTwinsPaged(query, callback) {

--- a/client/src/services/SignalRService.js
+++ b/client/src/services/SignalRService.js
@@ -9,13 +9,20 @@ import { print } from "./LoggingService";
 
 class SignalRService {
 
+  async addhttp(url) {
+    if (!/^(?:f|ht)tps?:\/\//.test(url)) {
+        url = "http://" + url;
+    }
+    return url;
+  }
+
   async initialize() {
     if (!this.connection) {
       try {
         const accessToken = await authService.login();
         const { appAdtUrl } = await configService.getConfig();
 
-        let signalRUrl = `/api/signalr/?x-adt-host=${new URL(appAdtUrl).hostname}`;
+        let signalRUrl = `/api/signalr/?x-adt-host=${new URL(await this.addhttp(appAdtUrl)).hostname}`;
         if (process.env.NODE_ENV === "development" && process.env.REACT_APP_BASE_ADT_URL) {
           signalRUrl = process.env.REACT_APP_BASE_ADT_URL + signalRUrl;
         }


### PR DESCRIPTION
If you're copying the ADT URL from the portal, it won't copy the http:// prefix which the app requires. This generates a SignalR failure on connection...This fix covers that by adding the http:// if it's missing.