### PR TITLE
Update the Docker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,18 +215,13 @@ Clicking the settings cog in the top right corner allows the configuration of th
 
 1. Set up an Azure Digital Twins service instance with an Azure Active Directory client app registration. For instructions, please see the following how-to articles:
     * [Set up an Azure Digital Twins instance](https://docs.microsoft.com/azure/digital-twins/how-to-set-up-instance)
-    * [Authenticate an Azure Digital Twins client application](https://docs.microsoft.com/azure/digital-twins/how-to-authenticate-client). The important part is the creation of the app registration (client id).
-      > A few important aspects for your app registrations:
-      > * Make sure you add app registrations to the Web platform section of the app registration, not the desktop/mobile section.
-      > * When adding callback URLs to the app registration, please make sure to add `http://localhost:3000`. You can run adt-explorer with a different port (see below), but this is the default.
-      > * Check the **Access Tokens** toggle in the **Implicit Grants** section a few paragraphs below the **Platform Configuration** section on the page. If this toggle is not checked, you will not get authorization tokens.  
 1. From a command prompt in the root folder, run `docker build -t adt-explorer .`. This will build the Docker image for the ADT explorer.
 1. From the same command prompt, run `docker run -it -p3000:3000 adt-explorer`.
     > By default, the app runs on port 3000. To customize the port, change the run command. For example, to use port 8080 run `docker run -it -p8080:3000 adt-explorer`
+    > A message will appear on the console asking you to login using a code in the Microsoft Login page with your web browser; after doing so the ADT explorer should start.
     >  * Note: When run successfully the application will display a message showing you the URL & port that you must open to browse the app. When running the app inside Docker this information might not be accurate, as other port might have been exposed. Be sure to use
     >  the port you chose before.
-    >  * Note: Your ADT app registration must have a reply URL using the same port you are using - e.g. `localhost:7000` if that is the port you are using.
-1. You can now open your web browser and browse to `http://localhost:3000` (change `3000` for the apropriate port, if you changed it) and the app should appear.
+1. You can now open your web browser and browse to `http://localhost:3000` (change `3000` for the apropriate port, if you changed it).
 
 ## Experimental Features
 

--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ Clicking the settings cog in the top right corner allows the configuration of th
     * [Set up an Azure Digital Twins instance](https://docs.microsoft.com/azure/digital-twins/how-to-set-up-instance)
 1. From a command prompt in the root folder, run `docker build -t adt-explorer .`. This will build the Docker image for the ADT explorer.
 1. From the same command prompt, run `docker run -it -p3000:3000 adt-explorer`.
-    > By default, the app runs on port 3000. To customize the port, change the run command. For example, to use port 8080 run `docker run -it -p8080:3000 adt-explorer`
-    > A message will appear on the console asking you to login using a code in the Microsoft Login page with your web browser; after doing so the ADT explorer should start.
+    > By default, the app runs on port 3000. To customize the port, change the run command. For example, to use port 8080 run `docker run -it -p8080:3000 adt-explorer`.
+    > A message will appear on the console asking you to login using a code in the Microsoft device login page with your web browser; after doing so the ADT explorer should start.
     >  * Note: When run successfully the application will display a message showing you the URL & port that you must open to browse the app. When running the app inside Docker this information might not be accurate, as other port might have been exposed. Be sure to use
     >  the port you chose before.
 1. You can now open your web browser and browse to `http://localhost:3000` (change `3000` for the apropriate port, if you changed it).


### PR DESCRIPTION
The changes explained in https://github.com/Azure-Samples/digital-twins-explorer/commit/52f6de60a04d32776a626ff05b59ae99656a0154 require the [`Dockerfile`](Dockerfile) & [`README.md`](README.md) to be updated accordingly, as explained in https://github.com/Azure-Samples/digital-twins-explorer/issues/54.

This PR implements the required changes, which can be basically summed up as:

- Bundle the AZ CLI into the docker image.
- Run `az login` when starting the container, before actually running `npm run start`.

Please note that, as described in the bug report, this build results in a fairly large (~1.4GB) docker image. I have, unsuccessfully, tried the following to reduce the image size:

- Multi-staged build → Running `npm run build` in the image results in memory errors. I have tried to increase the memory allocation to ~8GB but I understand that goes against the whole purpose of having .
- Unbundling the AZ CLI → It takes ~635MB, but not bundling it results in a poorer UX in my opinion since the user would still need to register the app in the Azure portal and expose the secrets as environment variables, which is much less user friendly.
- Changed the base image to `node:current-slim` → Does result in a small image size reduction.

Please let me know if you want me to explore other options.