### PR TITLE
Replaced deprecated node-sass with Dart Sass 1.32.4

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -24,7 +24,6 @@
     "jsonld-graph": "^3.0.10",
     "jsonlint": "^1.6.3",
     "msal": "^1.2.1",
-    "node-sass": "^4.14.1",
     "office-ui-fabric-react": "^7.117.4",
     "react": "^16.13.1",
     "react-console-emulator": "^4.0.1",
@@ -34,6 +33,7 @@
     "react-excel-renderer": "^1.1.0",
     "react-router-dom": "^5.1.2",
     "react-scripts": "^3.4.3",
+    "sass": "^1.32.4",
     "system": "^2.0.1",
     "typescript": "^3.7.5",
     "uuid": "^7.0.1"


### PR DESCRIPTION
### Reference Issues ###
Related to issue #93
### What does it fix ###
It replaces deprecated node-sass 4.14.1 with Dart Sass 1.32.4 as recommended by node-sass team. Previously used node-sass 4.14.1 required python2 what is EOL, node-sass 5.0 does not work with react do to sass-loader dependencies. 
Fix was _"tested"_ within the ADT learning path and removes dependency on python2.
