### PR TITLE
fix: Add ADT URL query parameter support

### DIFF
--- a/client/src/components/ConfigurationFormComponent/ConfigurationFormComponent.js
+++ b/client/src/components/ConfigurationFormComponent/ConfigurationFormComponent.js
@@ -53,6 +53,9 @@ export class ConfigurationFormComponent extends Component {
     };
     if (this.validateConfig(config)) {
       this.saveEnvironment(config);
+      const searchParams = new URLSearchParams(window.location.search);
+      searchParams.set("adtUrl", config.appAdtUrl);
+      window.location.search = searchParams.toString();
       eventService.publishConfigure({ type: "end", config });
       this.resetModalState();
     }

--- a/client/src/services/ConfigService.js
+++ b/client/src/services/ConfigService.js
@@ -21,6 +21,9 @@ class ConfigService {
   getConfig(force) {
     const config = storageService.getLocalStorageObject(StorageKeyName);
     if (config && !force) {
+      const params = new URLSearchParams(window.location.search);
+      const queryParamAppAdtUrl = params.get("adtUrl");
+      config.appAdtUrl = queryParamAppAdtUrl ? queryParamAppAdtUrl : config.appAdtUrl;
       return config;
     }
 


### PR DESCRIPTION
Add optional support to define the ADT endpoint as query parameter with the name **adtUrl=...**
Example: <http://localhost:3000/?adtUrl=https://prod-wus-sample-adt.api.wus2.digitaltwins.azure.net>