### PR TITLE
fix: property inspector truthy checks

### DIFF
--- a/client/src/components/PropertyInspectorComponent/PropertyInspectorComponent.js
+++ b/client/src/components/PropertyInspectorComponent/PropertyInspectorComponent.js
@@ -39,7 +39,8 @@ const applyDefaultValues = (properties, selection) => {
       continue;
     }
 
-    if (selection[p]) {
+    // eslint-disable-next-line no-undefined
+    if (selection[p] !== null && selection[p] !== undefined) {
       continue;
     }
 
@@ -64,8 +65,24 @@ const reTypeDelta = (properties, delta) => {
     }
 
     if (match && match.schema) {
-      d.value = modelService.getPropertyDefaultValue(match.schema, d.value);
-      if (d.value) {
+      let isRemoveOp = false;
+
+      if (d.value === null) {
+        isRemoveOp = true;
+      } else {
+        d.value = modelService.getPropertyDefaultValue(match.schema, d.value);
+      }
+
+      if (([ "dtmi:dtdl:instance:Schema:string;2", "string" ].includes(match.schema))) {
+        if (d.value === null) {
+          isRemoveOp = true;
+        }
+      } else if (d.value === null || d.value === "") {
+        isRemoveOp = true;
+      }
+
+      // eslint-disable-next-line no-negated-condition
+      if (!isRemoveOp) {
         if (match.schema.type === "Enum") {
           d.value = match.schema.values.filter(option =>
             option.displayName ? option.displayName === d.value : option.name === d.value)[0].value;


### PR DESCRIPTION
## Boolean values
- Fixes bug where setting `boolean` property to `false` creates ` "op": "remove"` patch and unsets the property
- Boolean properties can now be set to false in the inspector
## 0 as valid number
- Fixes bug where setting number property to `0` creates ` "op": "remove"` patch and unsets the property
- Number properties can now be set to false in the inspector
## Empty string
- Fixes bug where setting string property to `""` (empty string) creates ` "op": "remove"` patch and unsets the property
- Empty strings are now allowed as properties, but still show as `unset` in the property inspector.  Setting a string to empty will keep it as an active property.  To remove a string property, set to `null`.
- Showing empty string properties as `""` in the inspector is **out of the scope** of this fix.  This is due to the complexity of the **JsonEditor** component, how it handles empty input, and the CSS `content: "Unset"` rule being used.

## Removing properties
- To remove a property, set any property to `null` in the inspector.  This will force an ` "op": "remove"` patch and unset the property