### PR TITLE
Icon & tooltip fixes

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12376,6 +12376,11 @@
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
           "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
+        },
+        "underscore": {
+          "version": "1.12.1",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+          "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
         }
       }
     },
@@ -17267,11 +17272,6 @@
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
       "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
-    },
-    "underscore": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/client/src/components/GraphViewerComponent/GraphViewerCommandBarComponent/GraphViewerCommandBarComponent.js
+++ b/client/src/components/GraphViewerComponent/GraphViewerCommandBarComponent/GraphViewerCommandBarComponent.js
@@ -226,4 +226,4 @@ class GraphViewerCommandBarComponent extends Component {
 
 }
 
-export default withTranslation()(GraphViewerCommandBarComponent);
+export default withTranslation("translation", { withRef: true })(GraphViewerCommandBarComponent);

--- a/client/src/components/GraphViewerComponent/GraphViewerFilteringComponent/GraphViewerFilteringComponent.js
+++ b/client/src/components/GraphViewerComponent/GraphViewerFilteringComponent/GraphViewerFilteringComponent.js
@@ -42,13 +42,13 @@ const GraphViewerFilteringComponent = ({
         <Stack horizontal={false}>
           <div className="controls_buttonGroup">
             <IconButton
-              iconProps={{ iconName: "Add" }}
+              iconProps={{ iconName: "ZoomIn" }}
               title={t("graphViewerFilteringComponent.zoomIn")}
               ariaLabel={t("graphViewerFilteringComponent.zoomIn")}
               onClick={onZoomIn}
               className="control-loadButtons" />
             <IconButton
-              iconProps={{ iconName: "CalculatorSubtract" }}
+              iconProps={{ iconName: "ZoomOut" }}
               title={t("graphViewerFilteringComponent.zoomOut")}
               ariaLabel={t("graphViewerFilteringComponent.zoomOut")}
               onClick={onZoomOut}
@@ -56,7 +56,7 @@ const GraphViewerFilteringComponent = ({
           </div>
           <div className="controls_singleButton">
             <IconButton
-              iconProps={{ iconName: "FitPage" }}
+              iconProps={{ iconName: "SetToCenter" }}
               title={t("graphViewerFilteringComponent.center")}
               ariaLabel={t("graphViewerFilteringComponent.center")}
               onClick={onCenter}

--- a/client/src/components/ModelViewerComponent/ModelViewerComponent.scss
+++ b/client/src/components/ModelViewerComponent/ModelViewerComponent.scss
@@ -149,21 +149,3 @@
 .ms-SelectionZone {
   padding: 0 15px;
 }
-
-.ms-Callout-main {
-  margin-left: 55px;
-  margin-top: -30px;
-  border: 1px solid $backgroundColor4;
-  li {
-    border-bottom: 1px solid $backgroundColor4;
-    &:last-child {
-      border-bottom: none;
-    }
-  }
-  button {
-    &:focus {
-      background: #98E3FD !important;
-      color: $textColorDark1;
-    }
-  }
-}

--- a/client/src/components/ModelViewerComponent/ModelViewerItemCommandBarComponent/ModelViewerItemCommandBarComponent.js
+++ b/client/src/components/ModelViewerComponent/ModelViewerItemCommandBarComponent/ModelViewerItemCommandBarComponent.js
@@ -4,6 +4,7 @@
 import React, { Component } from "react";
 import { CommandBar } from "office-ui-fabric-react";
 import { withTranslation } from "react-i18next";
+import "./ModelViewerItemCommandBarComponent.scss";
 
 const buttonStyles = {
   fontSize: 14,
@@ -69,7 +70,20 @@ class ModelViewerItemCommandBarComponent extends Component {
             }
           }}
           overflowItems={showItemMenu ? this.overflowItems : []}
-          calloutProps={{ style: { background: "red" }}}
+          overflowButtonProps={{
+            menuProps: {
+              className: "model-viewer-item-command-bar-overflow-menu",
+              items: [],
+              calloutProps: {
+                styles: {
+                  root: {
+                    marginLeft: "55px",
+                    marginTop: "-30px"
+                  }
+                }
+              }
+            }
+          }}
           onKeyDown={this.props.onKeyDown}
           ariaLabel={this.props.t("modelViewerItemCommandBarComponent.ariaLabel")} />
       </div>

--- a/client/src/components/ModelViewerComponent/ModelViewerItemCommandBarComponent/ModelViewerItemCommandBarComponent.scss
+++ b/client/src/components/ModelViewerComponent/ModelViewerItemCommandBarComponent/ModelViewerItemCommandBarComponent.scss
@@ -1,0 +1,17 @@
+@import "../../../theme/theme.scss";
+
+.model-viewer-item-command-bar-overflow-menu {
+  border: 1px solid $backgroundColor4;
+  li {
+    border-bottom: 1px solid $backgroundColor4;
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+  button {
+    &:focus {
+      background: #98E3FD !important;
+      color: $textColorDark1;
+    }
+  }
+}


### PR DESCRIPTION
- Fixes regression of "setToCenter" and "zoomIn"/"zoomOut" icons
- Fixes bug where all fluent tooltips were broken.  This was caused by globally selecting all "ms-Callout-main" classes and applying margin.  The intent was to position the model viewer item overflow menu callout, but this also affected all tooltips.  I fixed this by moving the margin updates into Fluent's prop styling & moved the other styles into an isolated class.

Here's an image to show the bug that is being fixed!

![image](https://user-images.githubusercontent.com/18181049/123342203-2e66b300-d504-11eb-82af-29b16f976df5.png)
