### PR TITLE
Bumped cardboard version & PI updates

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1546,9 +1546,9 @@
       }
     },
     "@fluentui/react": {
-      "version": "8.36.5",
-      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.36.5.tgz",
-      "integrity": "sha512-M+V42WFT0vC1wBV1E3wE/FzeGKijnAdXJm9A4Bbm9cvG2ve1Tkf2joxS1blwsmzMy7rUCkrMNxCwVRNadU39Gw==",
+      "version": "8.37.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.37.0.tgz",
+      "integrity": "sha512-vwJA9KMTaqQ+JyDPGWTIgCcl8Z7hsBUyC4qRg8NqeoKNadhcWEHBzIcvSjjY/VaoQYQBEcdtaRrUmydxB02P3Q==",
       "requires": {
         "@fluentui/date-time-utilities": "^8.2.2",
         "@fluentui/font-icons-mdl2": "^8.1.14",
@@ -2487,9 +2487,9 @@
       }
     },
     "@microsoft/iot-cardboard-js": {
-      "version": "1.0.0-beta.50",
-      "resolved": "https://registry.npmjs.org/@microsoft/iot-cardboard-js/-/iot-cardboard-js-1.0.0-beta.50.tgz",
-      "integrity": "sha512-3WV8oiwbwSz9ENzEYFmufSuMbKih/3TjVkMMz4NhdnFp6JHNWJ0eqhqu4+/PgcquzzYzVhXzk3vSXNI45bDNmw==",
+      "version": "1.0.0-beta.52",
+      "resolved": "https://registry.npmjs.org/@microsoft/iot-cardboard-js/-/iot-cardboard-js-1.0.0-beta.52.tgz",
+      "integrity": "sha512-I+GogTS1mDp8EsSh3eWXUy6MhDYDL9pOcBMNjjW/6uPKZiTo6a9Qi8XP7Bw9akdu/YFlN3hxPW2vfRg81WT/gA==",
       "requires": {
         "@azure/msal-browser": "^2.11.0",
         "@fluentui/react": "^8.16.0",
@@ -4344,9 +4344,9 @@
       }
     },
     "axios-retry": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.2.tgz",
-      "integrity": "sha512-dalsS+nk+dw3KIJ+sXzNCAPWhgqWkJhfHFeDXBKJXo0S/Uc1YVHf+d9Vhh9WgoAFgSU2JgLnQjSB99rRfg29Sg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.3.tgz",
+      "integrity": "sha512-JfxUUN6PDyinrDVP/NbCKxmwvwJfMfQ0DLs95o/OEd+mw5+hrBXNGfx1Wq2gskd7ODWc4kcd9CjStCpDv3Us4g==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "is-retry-allowed": "^2.2.0"

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@azure/digital-twins-core": "^1.0.3",
     "@azure/identity": "^1.2.4",
-    "@microsoft/iot-cardboard-js": "^1.0.0-beta.50",
+    "@microsoft/iot-cardboard-js": "^1.0.0-beta.52",
     "@microsoft/signalr": "^3.1.11",
     "@types/react": "^16.14.2",
     "@types/react-dom": "^16.9.10",

--- a/client/src/components/PropertyInspectorComponent/PropertyInspectorComponent.js
+++ b/client/src/components/PropertyInspectorComponent/PropertyInspectorComponent.js
@@ -13,7 +13,7 @@ const pIActionTypes = {
     setSelectionType: 'setSelectionType',
     setSelection: 'setSelection',
     setRootAndExpandedModels: 'setRootAndExpandedModels',
-    setRelationshipDefinition: 'setRelationshipDefinition',
+    setRelationshipModel: 'setRelationshipModel',
     setIsSelectionLoading: 'setIsSelectionLoading',
     setIsPatchInformationVisible: 'setIsPatchInformationVisible',
     setPatchInformation: 'setPatchInformation',
@@ -32,8 +32,8 @@ const propertyInspectorReducer = produce((draft, action) => {
         case pIActionTypes.setRootAndExpandedModels:
             draft.rootAndExpandedModels = action.payload;
             break;
-        case pIActionTypes.setRelationshipDefinition:
-            draft.relationshipDefinition = action.payload;
+        case pIActionTypes.setRelationshipModel:
+            draft.relationshipModel = action.payload;
             break;
         case pIActionTypes.setIsSelectionLoading:
             draft.isSelectionLoading = action.payload;
@@ -66,7 +66,7 @@ const PropertyInspectorComponent = ({ isOpen }) => {
         selectionType: null,
         selection: null,
         rootAndExpandedModels: null,
-        relationshipDefinition: null,
+        relationshipModel: null,
         isSelectionLoading: false,
         isPatchInformationVisible: false,
         patchInformation: null,
@@ -181,7 +181,7 @@ const PropertyInspectorComponent = ({ isOpen }) => {
                     payload: sourceTwin['$metadata']['$model']
                 });
                 dispatch({
-                    type: pIActionTypes.setRelationshipDefinition,
+                    type: pIActionTypes.setRelationshipModel,
                     payload: null
                 });
             } else {
@@ -189,7 +189,7 @@ const PropertyInspectorComponent = ({ isOpen }) => {
                     models,
                     rootModel?.id
                 );
-                let relationshipDefinition = null;
+                let relationshipModel = null;
 
                 for (const model of expandedModels) {
                     if (model.contents) {
@@ -201,17 +201,17 @@ const PropertyInspectorComponent = ({ isOpen }) => {
                                 type === 'Relationship' &&
                                 selection['$relationshipName'] === item.name
                             ) {
-                                relationshipDefinition = item;
+                                relationshipModel = model;
                                 break;
                             }
                         }
                     }
-                    if (relationshipDefinition) break;
+                    if (relationshipModel) break;
                 }
 
                 dispatch({
-                    type: pIActionTypes.setRelationshipDefinition,
-                    payload: relationshipDefinition
+                    type: pIActionTypes.setRelationshipModel,
+                    payload: relationshipModel
                 });
             }
         }
@@ -397,7 +397,7 @@ const PropertyInspectorComponent = ({ isOpen }) => {
                     theme={'explorer'}
                     inputData={{
                         relationship: state.selection,
-                        relationshipDefinition: state.relationshipDefinition
+                        relationshipModel: state.relationshipModel
                     }}
                     onCommitChanges={onUpdateRelationship}
                     missingModelIds={state.missingModelIds}


### PR DESCRIPTION
Changes via cardboard dependency

- Added `DtdlSyntaxMap.ts` file to map expanded DTDL syntax into cardboard DTDL interfaces.  This allows for DTDL syntax such as `dtmi:dtdl:property:schema;2` when defining interfaces.  (Addresses https://github.com/Azure-Samples/digital-twins-explorer/issues/220)
- Added support for DTDL [schemas ](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/dtdlv2.md#interface-schemas) property on interfaces.  This allows for reusable schemas to be defined and used for complex  twin / relationship properties.  (Addresses https://github.com/Azure-Samples/digital-twins-explorer/issues/221)