### PR TITLE
Model upload with component references - bugfix 

### DIFF
--- a/client/src/components/ModelViewerComponent/ModelViewerComponent.js
+++ b/client/src/components/ModelViewerComponent/ModelViewerComponent.js
@@ -164,9 +164,9 @@ class ModelViewerComponent extends Component {
       const { items } = this.state;
       const modelService = new ModelService();
       const sortedModelsId = await modelService.getModelIdsForUpload(list);
-      sortedModels = sortedModelsId.map(id => list.filter(model => model["@id"] === id)[0]);
+      sortedModels = sortedModelsId.map(id => list.find(model => model["@id"] === id)).filter(m => !!m);
       sortedModels = sortedModels.filter(model => !items.some(item => item.key === model["@id"]));
-      if (sortedModels.length > 0) {
+      if (sortedModels && sortedModels.length > 0) {
         const chunks = modelService.chunkModelsList(sortedModels, 50);
         for (const chunk of chunks) {
           await this.createModels(chunk);


### PR DESCRIPTION
fixes #222  - issue where uploading model with references to components in different files failed due to logical bug.  Updating `addModels` function logic seems to fix this issue, although the code author should double check the edits to ensure this doesn't cause regressions.