### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ urlFragment: digital-twins-explorer
 
 <img src="https://raw.githubusercontent.com/Azure-Samples/digital-twins-explorer/main/media/digital-twins-explorer.png" alt="Image of digital-twins-explorer"/>
 
-Azure Digital Twins Explorer is written as a single-page JavaScript application. This repository holds the code for the hosted version of Azure Digital Twins Explorer, which is accessible through the [Azure portal](https://portal.azure.com) and at [explorer.digitaltwins.azure.net](explorer.digitaltwins.azure.net). You can also run the application locally as a node.js application.
+Azure Digital Twins Explorer is written as a single-page JavaScript application. This repository holds the code for the hosted version of Azure Digital Twins Explorer, which is accessible through the [Azure portal](https://portal.azure.com) and at [explorer.digitaltwins.azure.net](https://explorer.digitaltwins.azure.net). You can also run the application locally as a node.js application.
 
 This README contains information and guidance specific to hosting this codebase locally, including:
 * [Instructions to run the sample locally](#run-azure-digital-twins-explorer-locally)


### PR DESCRIPTION
Link currently goes to https://github.com/azure-samples/digital-twins-explorer/blob/main/explorer.digitaltwins.azure.net, when it should go to https://explorer.digitaltwins.azure.net