### PR TITLE
fixes error ERR_PACKAGE_PATH_NOT_EXPORTED

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:current-slim
+FROM node:lts-slim
 
 # Install required dependencies
 RUN apt-get update
@@ -15,7 +15,7 @@ WORKDIR /usr/src/app/client
 # where available (npm@5+)
 COPY ./client/package*.json ./
 WORKDIR /usr/src/app/client/src
-RUN npm install
+RUN npm install & npx browserslist@latest --update-db
 
 # Bundle app source
 WORKDIR /usr/src/app


### PR DESCRIPTION
this pins node to the LTS-slim
so it will at least work
and get updates

address #233 