### PR TITLE
Handle malformed configuration storage key

### DIFF
--- a/client/src/services/StorageService.js
+++ b/client/src/services/StorageService.js
@@ -5,6 +5,10 @@ class StorageService {
 
   getLocalStoragePrimitive = name => localStorage.getItem(name)
 
+  /* In the event that a local storage key is malformed (not JSON parsable),
+  we gracefully fallback. If it is for configuration,
+  we provide an appAdtUrl that is empty string to avoid object destructuring
+  issues on code blocks dependent on that specific structure */
   getLocalStorageObject = name => {
     try {
       return JSON.parse(localStorage.getItem(name));

--- a/client/src/services/StorageService.js
+++ b/client/src/services/StorageService.js
@@ -5,7 +5,13 @@ class StorageService {
 
   getLocalStoragePrimitive = name => localStorage.getItem(name)
 
-  getLocalStorageObject = name => JSON.parse(localStorage.getItem(name))
+  getLocalStorageObject = name => {
+    try {
+      return JSON.parse(localStorage.getItem(name));
+    } catch (e) {
+      return {appAdtUrl: ""};
+    }
+  }
 
   setLocalStorageObject = (name, dataObj) => localStorage.setItem(name, JSON.stringify(dataObj))
 

--- a/client/src/services/StorageService.js
+++ b/client/src/services/StorageService.js
@@ -9,7 +9,10 @@ class StorageService {
     try {
       return JSON.parse(localStorage.getItem(name));
     } catch (e) {
-      return {appAdtUrl: ""};
+      if (name === "configuration") {
+        return {appAdtUrl: ""};
+      }
+      return {};
     }
   }
 


### PR DESCRIPTION
In the event that a local storage key is malformed (not JSON parsable), we gracefully fallback.  If it is for configuration, we provide an appAdtUrl that is empty string to avoid object destructuring issues on code blocks dependent on that specific structure