### PR TITLE
Python installation failure fix when building dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:current-slim
 
 # Install required dependencies
 RUN apt-get update
-RUN apt-get -y install curl python make g++
+RUN apt-get -y install curl python3 make g++
 
 # Install the Azure CLI, which will be required for authentication
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash


### PR DESCRIPTION
While building Dockerfile, python installation failed due to version not mentioned in the Dockerfile. 

This pull request contains solution for the below issue. 

Error Logs of existing dockerfile build:
 => ERROR [ 3/14] RUN apt-get -y install curl python make g++                                                                                          2.0s
------
 > [ 3/14] RUN apt-get -y install curl python make g++:
0.747 Reading package lists...
1.642 Building dependency tree...
1.930 Reading state information...
1.940 Package python is not available, but is referred to by another package.
1.940 This may mean that the package is missing, has been obsoleted, or
1.940 is only available from another source
1.940 However the following packages replace it:
1.940   python-is-python3 2to3
1.940
1.942 E: Package 'python' has no installation candidate
------
Dockerfile:5
--------------------
   3 |     # Install required dependencies
   4 |     RUN apt-get update
   5 | >>> RUN apt-get -y install curl python make g++
   6 |
   7 |     # Install the Azure CLI, which will be required for authentication
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get -y install curl python make g++" did not complete successfully: exit code: 100